### PR TITLE
update gradlew to support JDK 14

### DIFF
--- a/server/build.gradle
+++ b/server/build.gradle
@@ -10,7 +10,7 @@ plugins {
   id "java"
   id "java-library"
   id "application"
-  id "nebula.ospackage-application" version "8.0.3"
+  id "nebula.ospackage-application" version "8.3.0"
 }
 
 group = 'org.swimos'

--- a/server/gradle/wrapper/gradle-wrapper.properties
+++ b/server/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 #Thu Dec 05 14:19:49 GMT 2019
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.0.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.4.1-bin.zip
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStorePath=wrapper/dists


### PR DESCRIPTION
Updating the gradle wrapper to support running the tutorial with JDK v.14 by

- Updating the classpath property in server/build.gradle to `'com.netflix.nebula:gradle-ospackage-plugin:8.3.0'`

- Updating the distributionUrl property in server/gradle/wrapper/gradle-wrapper.properties to `https\://services.gradle.org/distributions/gradle-6.4.1-bin.zip`