### PR TITLE
Tutorial solutions

### DIFF
--- a/server/README.md
+++ b/server/README.md
@@ -25,6 +25,12 @@ Continuing our analogy, *lane callback* functions serve as the "methods" of Web 
 
 Each lane type defines a set of overridable (default no-op) lifecycle callbacks. For example, [sending a command message](#sending-data-do-swim) to any command lane will trigger its [`onCommand` callback](http://github.com/swimos/tutorial/tree/master/server/src/main/java/swim/tutorial/UnitAgent.java#L51-L54). On the other hand, [setting a value lane](http://github.com/swimos/tutorial/tree/master/server/src/main/java/swim/tutorial/UnitAgent.java#L53) will trigger its `willSet` callback, then update its value, then trigger its [`didSet` callback](http://github.com/swimos/tutorial/tree/master/server/src/main/java/swim/tutorial/UnitAgent.java#L40-L47).
 
+#### *Try it yourself:* 
+- [ ] *Navigate to [swim.tutorial.UnitAgent.java](https://github.com/swimos/tutorial/blob/master/server/src/main/java/swim/tutorial/UnitAgent.java)*
+- [ ] *Fill in the remaining code to create a new value lane called `stats` which gets populated by changes to the `histogram` map lane*
+- [ ] *Experiment with ways to transform the data entries in histogram. Ideas: mean, median, range, standard deviation, variance, etc!*
+- [ ] *Compare your answer with those in the [**tutorial_solutions**](https://github.com/swimos/tutorial/tree/tutorial_solutions) branch*
+
 Visit the [documentation](https://developer.swim.ai/concepts/lanes/) for further details about lanes.
 
 ## Standing a Swim Server

--- a/server/README.md
+++ b/server/README.md
@@ -54,3 +54,10 @@ Visit the [documentation](https://developer.swim.ai/concepts) for further detail
 Swim client instances use Swim **links** to pull data from a Swim lanes. Like their corresponding lanes, links have overridable callback functions that can be used to [populate UIs](http://github.com/swimos/tutorial/tree/master/ui/index.html#L116-L141).
 
 Visit the [documentation](https://developer.swim.ai/concepts/links/) for further details about links.
+
+## *Visualizing Your Changes in the UI*
+
+- [ ] *Consider how the above changes to the server code may change the way you'd want to visualize your data*
+- [ ] *Navigate to the [ui folder](https://github.com/swimos/tutorial/tree/master/ui)*
+- [ ] *Experiment with the UI code to accommodate for your server-side changes*
+- [ ] *See the [**tutorial_solutions**](https://github.com/swimos/tutorial/tree/tutorial_solutions) branch for an example of this*

--- a/server/README.md
+++ b/server/README.md
@@ -10,6 +10,11 @@ Swim implements a general purpose distributed object model. The "objects" in thi
 
 [Creating a class](http://github.com/swimos/tutorial/tree/master/server/src/main/java/swim/tutorial/UnitAgent.java#L13) that extends `swim.api.agent.AbstractAgent` defines a *template* for Web Agents (though not a useful one until we add some [lanes](#lanes)).
 
+#### *Try it yourself:* 
+- [ ] *Navigate to [swim.tutorial.DataSource.java](https://github.com/swimos/tutorial/blob/master/server/src/main/java/swim/tutorial/DataSource.java)*
+- [ ] *Create additional web agents using the instructions in the code*
+- [ ] *Compare your answer with those in the [**tutorial_solutions**](https://github.com/swimos/tutorial/tree/tutorial_solutions) branch*
+
 Visit the [documentation](https://developer.swim.ai/concepts/agents/) for further details about Web Agents.
 
 ## Lanes

--- a/server/README.md
+++ b/server/README.md
@@ -11,7 +11,7 @@ Swim implements a general purpose distributed object model. The "objects" in thi
 [Creating a class](http://github.com/swimos/tutorial/tree/master/server/src/main/java/swim/tutorial/UnitAgent.java#L13) that extends `swim.api.agent.AbstractAgent` defines a *template* for Web Agents (though not a useful one until we add some [lanes](#lanes)).
 
 #### *Example Solutions*
-- *Created two additional web agents in (DataSource)[https://github.com/swimos/tutorial/blob/solutions/server/src/main/java/swim/tutorial/DataSource.java]*
+- *Created two additional web agents in [DataSource](https://github.com/swimos/tutorial/blob/solutions/server/src/main/java/swim/tutorial/DataSource.java)*
 - *Created unique Records (msg2 and msg3) to vary the data sent to different agents*
 
 Visit the [documentation](https://developer.swim.ai/concepts/agents/) for further details about Web Agents.
@@ -25,7 +25,7 @@ Continuing our analogy, *lane callback* functions serve as the "methods" of Web 
 Each lane type defines a set of overridable (default no-op) lifecycle callbacks. For example, [sending a command message](#sending-data-do-swim) to any command lane will trigger its [`onCommand` callback](http://github.com/swimos/tutorial/tree/master/server/src/main/java/swim/tutorial/UnitAgent.java#L51-L54). On the other hand, [setting a value lane](http://github.com/swimos/tutorial/tree/master/server/src/main/java/swim/tutorial/UnitAgent.java#L53) will trigger its `willSet` callback, then update its value, then trigger its [`didSet` callback](http://github.com/swimos/tutorial/tree/master/server/src/main/java/swim/tutorial/UnitAgent.java#L40-L47).
 
 #### *Example Solutions*
-- *Added 5 new SwimLanes in (UnitAgent)[https://github.com/swimos/tutorial/blob/solutions/server/src/main/java/swim/tutorial/UnitAgent.java]*
+- *Added 5 new SwimLanes in [UnitAgent](https://github.com/swimos/tutorial/blob/solutions/server/src/main/java/swim/tutorial/UnitAgent.java)*
 	- *the 'avg' ValueLane keeps track of changes to the mean cumulatively*
 	- *the 'localAvg', 'localVar', and 'localStdDev' ValueLanes run calculations on the 5 most recent data points sent from histogram*
 	- *the 'stats' ValueLane is an alternative design choice which tracks each of the above metrics using one lane of type Value (rather than 4 individual lanes of type Long)*

--- a/server/README.md
+++ b/server/README.md
@@ -10,10 +10,9 @@ Swim implements a general purpose distributed object model. The "objects" in thi
 
 [Creating a class](http://github.com/swimos/tutorial/tree/master/server/src/main/java/swim/tutorial/UnitAgent.java#L13) that extends `swim.api.agent.AbstractAgent` defines a *template* for Web Agents (though not a useful one until we add some [lanes](#lanes)).
 
-#### *Try it yourself:* 
-- [ ] *Navigate to [swim.tutorial.DataSource.java](https://github.com/swimos/tutorial/blob/master/server/src/main/java/swim/tutorial/DataSource.java)*
-- [ ] *Create additional web agents using the instructions in the code*
-- [ ] *Compare your answer with those in the [**tutorial_solutions**](https://github.com/swimos/tutorial/tree/tutorial_solutions) branch*
+#### *Example Solutions*
+- *Created two additional web agents in (DataSource)[https://github.com/swimos/tutorial/blob/solutions/server/src/main/java/swim/tutorial/DataSource.java]*
+- *Created unique Records (msg2 and msg3) to vary the data sent to different agents*
 
 Visit the [documentation](https://developer.swim.ai/concepts/agents/) for further details about Web Agents.
 
@@ -25,11 +24,11 @@ Continuing our analogy, *lane callback* functions serve as the "methods" of Web 
 
 Each lane type defines a set of overridable (default no-op) lifecycle callbacks. For example, [sending a command message](#sending-data-do-swim) to any command lane will trigger its [`onCommand` callback](http://github.com/swimos/tutorial/tree/master/server/src/main/java/swim/tutorial/UnitAgent.java#L51-L54). On the other hand, [setting a value lane](http://github.com/swimos/tutorial/tree/master/server/src/main/java/swim/tutorial/UnitAgent.java#L53) will trigger its `willSet` callback, then update its value, then trigger its [`didSet` callback](http://github.com/swimos/tutorial/tree/master/server/src/main/java/swim/tutorial/UnitAgent.java#L40-L47).
 
-#### *Try it yourself:* 
-- [ ] *Navigate to [swim.tutorial.UnitAgent.java](https://github.com/swimos/tutorial/blob/master/server/src/main/java/swim/tutorial/UnitAgent.java)*
-- [ ] *Fill in the remaining code to create a new value lane called `stats` which gets populated by changes to the `histogram` map lane*
-- [ ] *Experiment with ways to transform the data entries in histogram. Ideas: mean, median, range, standard deviation, variance, etc!*
-- [ ] *Compare your answer with those in the [**tutorial_solutions**](https://github.com/swimos/tutorial/tree/tutorial_solutions) branch*
+#### *Example Solutions*
+- *Added 5 new SwimLanes in (UnitAgent)[https://github.com/swimos/tutorial/blob/solutions/server/src/main/java/swim/tutorial/UnitAgent.java]*
+	- *the 'avg' ValueLane keeps track of changes to the mean cumulatively*
+	- *the 'localAvg', 'localVar', and 'localStdDev' ValueLanes run calculations on the 5 most recent data points sent from histogram*
+	- *the 'stats' ValueLane is an alternative design choice which tracks each of the above metrics using one lane of type Value (rather than 4 individual lanes of type Long)*
 
 Visit the [documentation](https://developer.swim.ai/concepts/lanes/) for further details about lanes.
 
@@ -57,7 +56,4 @@ Visit the [documentation](https://developer.swim.ai/concepts/links/) for further
 
 ## *Visualizing Your Changes in the UI*
 
-- [ ] *Consider how the above changes to the server code may change the way you'd want to visualize your data*
-- [ ] *Navigate to the [ui folder](https://github.com/swimos/tutorial/tree/master/ui)*
-- [ ] *Experiment with the UI code to accommodate for your server-side changes*
-- [ ] *See the [**tutorial_solutions**](https://github.com/swimos/tutorial/tree/tutorial_solutions) branch for an example of this*
+- *See the [**solutions**](https://github.com/swimos/tutorial/tree/solutions/ui) branch for an example of changes you could make to the UI to reflect these possible solutions*

--- a/server/src/main/java/swim/tutorial/DataSource.java
+++ b/server/src/main/java/swim/tutorial/DataSource.java
@@ -39,7 +39,14 @@ class DataSource {
       //   *CommandLane* addressable by "publish" OF the
       //   *Web Agent* addressable by "/unit/master" RUNNING ON the
       //   *(Swim) server* addressable by hostUri
-      this.ref.command(this.hostUri, "/unit/master", "publish", msg);
+      this.ref.command(this.hostUri, "/unit/master1", "publish", msg);
+      
+      // add agents by following the format of the hostURI specified in TutorialPlane
+      // line 12: @SwimRoute("/unit/:id")
+      
+      // this.ref.command(this.hostUri, "/unit/master2", "publish", msg);
+      // this.ref.command(this.hostUri, "/unit/master3", "publish", msg);
+      
       indicator = (indicator + 1) % 1000;
 
       // Throttle events to four every three seconds

--- a/server/src/main/java/swim/tutorial/DataSource.java
+++ b/server/src/main/java/swim/tutorial/DataSource.java
@@ -44,6 +44,8 @@ class DataSource {
       // To instantiate more agents, follow the format of the URI pattern specified in TutorialPlane
       //   see line 12: @SwimRoute("/unit/:id")
       
+      // TODO: create two new web agents using the above format
+      
       // EXAMPLES:
       // this.ref.command(this.hostUri, "/unit/secondAgent", "publish", msg);
       // this.ref.command(this.hostUri, "/unit/thirdAgent", "publish", msg);

--- a/server/src/main/java/swim/tutorial/DataSource.java
+++ b/server/src/main/java/swim/tutorial/DataSource.java
@@ -39,13 +39,14 @@ class DataSource {
       //   *CommandLane* addressable by "publish" OF the
       //   *Web Agent* addressable by "/unit/master" RUNNING ON the
       //   *(Swim) server* addressable by hostUri
-      this.ref.command(this.hostUri, "/unit/master1", "publish", msg);
+      this.ref.command(this.hostUri, "/unit/master", "publish", msg);
       
-      // add agents by following the format of the hostURI specified in TutorialPlane
-      // line 12: @SwimRoute("/unit/:id")
+      // To instantiate more agents, follow the format of the URI pattern specified in TutorialPlane
+      //   see line 12: @SwimRoute("/unit/:id")
       
-      // this.ref.command(this.hostUri, "/unit/master2", "publish", msg);
-      // this.ref.command(this.hostUri, "/unit/master3", "publish", msg);
+      // EXAMPLES:
+      // this.ref.command(this.hostUri, "/unit/secondAgent", "publish", msg);
+      // this.ref.command(this.hostUri, "/unit/thirdAgent", "publish", msg);
       
       indicator = (indicator + 1) % 1000;
 

--- a/server/src/main/java/swim/tutorial/DataSource.java
+++ b/server/src/main/java/swim/tutorial/DataSource.java
@@ -46,7 +46,7 @@ class DataSource {
       
       // TODO: Create two new web agents using the above format
       
-      // EXAMPLE SOLUTION:
+   // ***** EXAMPLE SOLUTION ******
       // this.ref.command(this.hostUri, "/unit/secondAgent", "publish", msg);
       // this.ref.command(this.hostUri, "/unit/thirdAgent", "publish", msg);
       

--- a/server/src/main/java/swim/tutorial/DataSource.java
+++ b/server/src/main/java/swim/tutorial/DataSource.java
@@ -43,8 +43,20 @@ class DataSource {
             
       // *********************** EXAMPLE SOLUTION ***********************
       
-      this.ref.command(this.hostUri, "/unit/secondAgent", "publish", msg);
-      this.ref.command(this.hostUri, "/unit/thirdAgent", "publish", msg);
+      
+      // change and round scale of foo, bar, baz to make data sent to different agents more distinct and recognizable from each other
+      final Record msg2 = Record.create(3)
+              .slot("foo", (double)Math.round((foo + 20) * .5))
+              .slot("bar", (double)Math.round((bar - 25) * 1.05))
+              .slot("baz", (double)Math.round(baz * .5));
+      
+      final Record msg3 = Record.create(3)
+              .slot("foo", (double)Math.round((foo + 5) * .5))
+              .slot("bar", (double)Math.round((bar + 5) * .75))
+              .slot("baz", (double)Math.round((baz + 10) * .15));
+      
+      this.ref.command(this.hostUri, "/unit/secondAgent", "publish", msg2);
+      this.ref.command(this.hostUri, "/unit/thirdAgent", "publish", msg3);
       
       // ****************************************************************
       

--- a/server/src/main/java/swim/tutorial/DataSource.java
+++ b/server/src/main/java/swim/tutorial/DataSource.java
@@ -40,15 +40,13 @@ class DataSource {
       //   *Web Agent* addressable by "/unit/master" RUNNING ON the
       //   *(Swim) server* addressable by hostUri
       this.ref.command(this.hostUri, "/unit/master", "publish", msg);
+            
+      // *********************** EXAMPLE SOLUTION ***********************
       
-      // To instantiate more agents, follow the format of the URI pattern specified in TutorialPlane
-      //   see line 12: @SwimRoute("/unit/:id")
+      this.ref.command(this.hostUri, "/unit/secondAgent", "publish", msg);
+      this.ref.command(this.hostUri, "/unit/thirdAgent", "publish", msg);
       
-      // TODO: Create two new web agents using the above format
-      
-   // ***** EXAMPLE SOLUTION ******
-      // this.ref.command(this.hostUri, "/unit/secondAgent", "publish", msg);
-      // this.ref.command(this.hostUri, "/unit/thirdAgent", "publish", msg);
+      // ****************************************************************
       
       indicator = (indicator + 1) % 1000;
 

--- a/server/src/main/java/swim/tutorial/DataSource.java
+++ b/server/src/main/java/swim/tutorial/DataSource.java
@@ -44,9 +44,9 @@ class DataSource {
       // To instantiate more agents, follow the format of the URI pattern specified in TutorialPlane
       //   see line 12: @SwimRoute("/unit/:id")
       
-      // TODO: create two new web agents using the above format
+      // TODO: Create two new web agents using the above format
       
-      // EXAMPLES:
+      // EXAMPLE SOLUTION:
       // this.ref.command(this.hostUri, "/unit/secondAgent", "publish", msg);
       // this.ref.command(this.hostUri, "/unit/thirdAgent", "publish", msg);
       

--- a/server/src/main/java/swim/tutorial/UnitAgent.java
+++ b/server/src/main/java/swim/tutorial/UnitAgent.java
@@ -115,7 +115,7 @@ public class UnitAgent extends AbstractAgent {
 	    	  	  
 	    	  // remove logic for stats
 	    	  Value updated_stats = Record.create(4).slot("avg", setUpdatedAvg).slot("localAvg", setLocalAvg).slot("localVar", setLocalVar).slot("localStdDev", setLocalStdDev);
-		      stats.set(updated_stats); 
+		      stats.set(updatedStats); 
 	    	  
 	      });
 	  

--- a/server/src/main/java/swim/tutorial/UnitAgent.java
+++ b/server/src/main/java/swim/tutorial/UnitAgent.java
@@ -12,14 +12,27 @@ import swim.structure.Value;
 import java.util.Iterator;
 
 public class UnitAgent extends AbstractAgent {
+  
+  // TODO: complete the stats Value Lane
+  // @SwimLane("stats")
+	
+  // HINT: Use the valueLane() method to instantiate the lane
+  // HINT: Use the .didSet() lifecycle callback to log a message showing updates to stats
+	
+   @SwimLane("histogram")
+   private final MapLane<Long, Value> histogram = this.<Long, Value>mapLane()
+       .didUpdate((k, n, o) -> {
+         logMessage("histogram: replaced " + k + "'s value to " + Recon.toString(n) + " from " + Recon.toString(o));
+         // TODO: update stats with update logic
+         
+		 dropOldData();
 
-  @SwimLane("histogram")
-  private final MapLane<Long, Value> histogram = this.<Long, Value>mapLane()
-      .didUpdate((k, n, o) -> {
-        logMessage("histogram: replaced " + k + "'s value to " + Recon.toString(n) + " from " + Recon.toString(o));
-        dropOldData();
-      });
+       })
+       .didRemove((k,o) -> {
+        // TODO: update stats with remove logic
 
+       });
+		  
   @SwimLane("history")
   private final ListLane<Value> history = this.<Value>listLane()
       .didUpdate((idx, newValue, oldValue) -> {

--- a/server/src/main/java/swim/tutorial/UnitAgent.java
+++ b/server/src/main/java/swim/tutorial/UnitAgent.java
@@ -12,26 +12,66 @@ import swim.structure.Value;
 import java.util.Iterator;
 
 public class UnitAgent extends AbstractAgent {
-  
-  // TODO: complete the stats Value Lane
-  // @SwimLane("stats")
+	  // instance variables to track metrics going into stats
+	  private long count_sum = 0;
+	  private int count_total = 0;
+	  
+	  @SwimLane("stats")
+	  private final ValueLane<Long> stats = this.<Long>valueLane()
+	  .didSet((n, o) -> {
+	    logMessage("stats: mean updated to " + n + " from " + o);
+	  });
 	
-  // HINT: Use the valueLane() method to instantiate the lane
-  // HINT: Use the .didSet() lifecycle callback to log a message showing updates to stats
 	
-   @SwimLane("histogram")
-   private final MapLane<Long, Value> histogram = this.<Long, Value>mapLane()
-       .didUpdate((k, n, o) -> {
-         logMessage("histogram: replaced " + k + "'s value to " + Recon.toString(n) + " from " + Recon.toString(o));
-         // TODO: update stats with update logic
-         
-		 dropOldData();
-
-       })
-       .didRemove((k,o) -> {
-        // TODO: update stats with remove logic
-
-       });
+	  @SwimLane("histogram")
+	  private final MapLane<Long, Value> histogram = this.<Long, Value>mapLane()
+	      .didUpdate((k, n, o) -> {
+	        logMessage("histogram: replaced " + k + "'s value to " + Recon.toString(n) + " from " + Recon.toString(o));
+	        
+	        // calculating mean to send to stats
+	        count_sum += n.getItem(0).longValue();
+	        // logMessage(count_sum);
+	        
+	        count_total ++;
+	        // logMessage(count_total);
+	        
+	        final long avg = count_sum / count_total;
+	        // logMessage(avg);
+	        
+	        stats.set(avg);
+	        
+	        dropOldData();
+	      })
+	      .didRemove((k,o) -> {
+	        // update stats with remove logic
+	    	  logMessage("histogram: removed <" + k + "," + Recon.toString(o) + ">");
+	    	  count_sum = 0;
+	    	  count_total = 0;
+	      });
+	  
+	
+	
+	// tutorial outline
+	
+//  // TODO: complete the stats Value Lane
+//  // @SwimLane("stats")
+//	
+//  // HINT: Use the valueLane() method to instantiate the lane
+//  // HINT: Use the .didSet() lifecycle callback to log a message showing updates to stats
+//	
+//   @SwimLane("histogram")
+//   private final MapLane<Long, Value> histogram = this.<Long, Value>mapLane()
+//       .didUpdate((k, n, o) -> {
+//         logMessage("histogram: replaced " + k + "'s value to " + Recon.toString(n) + " from " + Recon.toString(o));
+//         // TODO: update stats with update logic
+//         
+//		 dropOldData();
+//
+//       })
+//       .didRemove((k,o) -> {
+//        // TODO: update stats with remove logic
+//
+//       });
 		  
   @SwimLane("history")
   private final ListLane<Value> history = this.<Value>listLane()

--- a/server/src/main/java/swim/tutorial/UnitAgent.java
+++ b/server/src/main/java/swim/tutorial/UnitAgent.java
@@ -98,6 +98,7 @@ public class UnitAgent extends AbstractAgent {
 	        dropOldData();
 	      })
 	      .didRemove((k,o) -> {
+	    	  // remove logic typically follows this format:
 	    	  // stats.put(stats.get()-o)
 	    	  
 	    	  logMessage("histogram: removed <" + k + "," + Recon.toString(o) + ">");
@@ -105,33 +106,14 @@ public class UnitAgent extends AbstractAgent {
 	    	  // remove logic for avg lane
 	    	  countSum -= o.getItem(0).longValue();
 	    	  countTotal --;
-	    	  avg.put(countSum / countTotal)
+	    	  AVG = countSum / countTotal;
+	    	  avg.set(AVG)
 	    	  
-	    	  // remove logic for local avg lane
-	    	  localSum -= o.getItem(0).longValue()
-	    	  newLocAvg = localSum/(long) (recentData.length-1);
-	    	  localAvg.put(newLocAvg)
-	    	  
-	    	  // remove logic for local var lane
-	    	  
-	    	  long squaredDifSum = 0; // (sum of local mean - each value)^2
-		        for (long d : recentData) squaredDifSum += (d - LOCAL_AVG)*(d - LOCAL_AVG);
-		        final long LOCAL_VAR = squaredDifSum/recentData.length;
-		        localVar.set(LOCAL_VAR);
-
-		      for (long d : recentData) {
-		    	  if (d.equals())
-		      }
-	    	  
-		      final long LOCAL_AVG = localSum / (long) recentData.length;
-		      localAvg.set(LOCAL_AVG);
-	    	  
-	    	  squaredDifSum-()*()/
-	    	  recentData.length-1
-	    	  
-	    	  // remove logic for avg lane
+	    	  // stats based only on the most recent inputs (i.e. localAvg, et al) will constantly update already
 	    	  	  
 	    	  // remove logic for stats
+	    	  all_stats = Record.create(4).slot("AVG", AVG).slot("LOCAL_AVG", LOCAL_AVG).slot("LOCAL_VAR", LOCAL_VAR).slot("LOCAL_STD_DEV", LOCAL_STD_DEV);
+		      stats.set(all_stats); 
 	    	  
 	      });
 	  

--- a/server/src/main/java/swim/tutorial/UnitAgent.java
+++ b/server/src/main/java/swim/tutorial/UnitAgent.java
@@ -48,8 +48,7 @@ public class UnitAgent extends AbstractAgent {
 	  });
 	  
 	  
-	  // TODO: combine all calculations into one swimlane of type Value
-	  
+	  // combination all calculations into one swim lane of type Value
 	  @SwimLane("stats")
 	  private final ValueLane<Value> stats = this.<Value>valueLane()
 	  .didSet((n, o) -> {
@@ -106,14 +105,17 @@ public class UnitAgent extends AbstractAgent {
 	    	  // remove logic for avg lane
 	    	  countSum -= o.getItem(0).longValue();
 	    	  countTotal --;
-	    	  AVG = countSum / countTotal;
-	    	  avg.set(AVG)
+	    	  final long UPDATED_AVG = countSum / countTotal;
+	    	  avg.set(UPDATED_AVG);
 	    	  
 	    	  // stats based only on the most recent inputs (i.e. localAvg, et al) will constantly update already
+	    	  final long LOCAL_AVG = localAvg.get();
+	    	  final long LOCAL_VAR = localVar.get();
+	    	  final long LOCAL_STD_DEV = localStdDev.get();
 	    	  	  
 	    	  // remove logic for stats
-	    	  all_stats = Record.create(4).slot("AVG", AVG).slot("LOCAL_AVG", LOCAL_AVG).slot("LOCAL_VAR", LOCAL_VAR).slot("LOCAL_STD_DEV", LOCAL_STD_DEV);
-		      stats.set(all_stats); 
+	    	  Value updated_stats = Record.create(4).slot("AVG", UPDATED_AVG).slot("LOCAL_AVG", LOCAL_AVG).slot("LOCAL_VAR", LOCAL_VAR).slot("LOCAL_STD_DEV", LOCAL_STD_DEV);
+		      stats.set(updated_stats); 
 	    	  
 	      });
 	  

--- a/server/src/main/java/swim/tutorial/UnitAgent.java
+++ b/server/src/main/java/swim/tutorial/UnitAgent.java
@@ -64,8 +64,8 @@ public class UnitAgent extends AbstractAgent {
 	        // calculating overall mean to send to average lane
 	        countSum += n.getItem(0).longValue();
 	        countTotal ++;
-	        final long AVG = countSum / countTotal;
-	        avg.set(AVG);
+	        final long setAvg = countSum / countTotal;
+	        avg.set(setAvg);
 	        
 	        // appending new data to the recentData array
 	        if (index >= recentData.length-1) {
@@ -77,21 +77,21 @@ public class UnitAgent extends AbstractAgent {
 	        // calculating local mean to send to local average lane
 	        long localSum = 0;
 	        for (long d : recentData) localSum += d;
-	        final long LOCAL_AVG = localSum / (long) recentData.length;
-	        localAvg.set(LOCAL_AVG);
+	        final long setLocalAvg = localSum / (long) recentData.length;
+	        localAvg.set(setLocalAvg);
 	        
 	        // calculating local variance to send to local var lane
 	        long squaredDifSum = 0; // (sum of local mean - each value)^2
-	        for (long d : recentData) squaredDifSum += (d - LOCAL_AVG)*(d - LOCAL_AVG);
-	        final long LOCAL_VAR = squaredDifSum/recentData.length;
-	        localVar.set(LOCAL_VAR);
+	        for (long d : recentData) squaredDifSum += (d - setLocalAvg)*(d - setLocalAvg);
+	        final long setLocalVar = squaredDifSum/recentData.length;
+	        localVar.set(setLocalVar);
 	        
 	        // calculating local standard deviation to send to local standard deviation lane
-	        final long LOCAL_STD_DEV = (long)Math.sqrt(LOCAL_VAR);
-	        localStdDev.set(LOCAL_STD_DEV);
+	        final long setLocalStdDev = (long)Math.sqrt(setLocalVar);
+	        localStdDev.set(setLocalStdDev);
 	        
 	        // Consolidating all data to the valuelane stats of type value
-	        Value all_stats = Record.create(4).slot("AVG", AVG).slot("LOCAL_AVG", LOCAL_AVG).slot("LOCAL_VAR", LOCAL_VAR).slot("LOCAL_STD_DEV", LOCAL_STD_DEV);
+	        Value all_stats = Record.create(4).slot("avg", setAvg).slot("localAvg", setLocalAvg).slot("localVar", setLocalVar).slot("localStdDev", setLocalStdDev);
 	        stats.set(all_stats); 
 	        
 	        dropOldData();
@@ -105,16 +105,16 @@ public class UnitAgent extends AbstractAgent {
 	    	  // remove logic for avg lane
 	    	  countSum -= o.getItem(0).longValue();
 	    	  countTotal --;
-	    	  final long UPDATED_AVG = countSum / countTotal;
-	    	  avg.set(UPDATED_AVG);
+	    	  final long setUpdatedAvg = countSum / countTotal;
+	    	  avg.set(setUpdatedAvg);
 	    	  
 	    	  // stats based only on the most recent inputs (i.e. localAvg, et al) will constantly update already
-	    	  final long LOCAL_AVG = localAvg.get();
-	    	  final long LOCAL_VAR = localVar.get();
-	    	  final long LOCAL_STD_DEV = localStdDev.get();
+	    	  final long setLocalAvg = localAvg.get();
+	    	  final long setLocalVar = localVar.get();
+	    	  final long setLocalStdDev = localStdDev.get();
 	    	  	  
 	    	  // remove logic for stats
-	    	  Value updated_stats = Record.create(4).slot("AVG", UPDATED_AVG).slot("LOCAL_AVG", LOCAL_AVG).slot("LOCAL_VAR", LOCAL_VAR).slot("LOCAL_STD_DEV", LOCAL_STD_DEV);
+	    	  Value updated_stats = Record.create(4).slot("avg", setUpdatedAvg).slot("localAvg", setLocalAvg).slot("localVar", setLocalVar).slot("localStdDev", setLocalStdDev);
 		      stats.set(updated_stats); 
 	    	  
 	      });

--- a/server/src/main/java/swim/tutorial/UnitAgent.java
+++ b/server/src/main/java/swim/tutorial/UnitAgent.java
@@ -63,7 +63,7 @@ public class UnitAgent extends AbstractAgent {
 	        
 	        // calculating overall mean to send to average lane
 	        countSum += n.get("count").longValue();
-	        countTotal ++;
+	        countTotal++;
 	        final long setAvg = countSum / countTotal;
 	        avg.set(setAvg);
 	        
@@ -72,7 +72,7 @@ public class UnitAgent extends AbstractAgent {
 	        	index = 0;
 	        }
 	        recentData[index] = n.get("count").longValue();
-	        index ++;
+	        index++;
 	        
 	        // calculating local mean to send to local average lane
 	        long localSum = 0;
@@ -104,7 +104,7 @@ public class UnitAgent extends AbstractAgent {
 	    	  
 	    	  // remove logic for avg lane
 	    	  countSum -= o.get("count").longValue() ;
-	    	  countTotal --;
+	    	  countTotal--;
 	    	  final long setUpdatedAvg = countSum / countTotal;
 	    	  avg.set(setUpdatedAvg);
 	    	  

--- a/server/src/main/java/swim/tutorial/UnitAgent.java
+++ b/server/src/main/java/swim/tutorial/UnitAgent.java
@@ -62,7 +62,7 @@ public class UnitAgent extends AbstractAgent {
 	        logMessage("histogram: replaced " + k + "'s value to " + Recon.toString(n) + " from " + Recon.toString(o));
 	        
 	        // calculating overall mean to send to average lane
-	        countSum += n.getItem(0).longValue();
+	        countSum += n.get("count").longValue();
 	        countTotal ++;
 	        final long setAvg = countSum / countTotal;
 	        avg.set(setAvg);
@@ -71,7 +71,7 @@ public class UnitAgent extends AbstractAgent {
 	        if (index >= recentData.length-1) {
 	        	index = 0;
 	        }
-	        recentData[index] = n.getItem(0).longValue();
+	        recentData[index] = n.get("count").longValue();
 	        index ++;
 	        
 	        // calculating local mean to send to local average lane
@@ -103,7 +103,7 @@ public class UnitAgent extends AbstractAgent {
 	    	  logMessage("histogram: removed <" + k + "," + Recon.toString(o) + ">");
 	    	  
 	    	  // remove logic for avg lane
-	    	  countSum -= o.getItem(0).longValue();
+	    	  countSum -= o.get("count").longValue() ;
 	    	  countTotal --;
 	    	  final long setUpdatedAvg = countSum / countTotal;
 	    	  avg.set(setUpdatedAvg);

--- a/server/src/main/java/swim/tutorial/UnitAgent.java
+++ b/server/src/main/java/swim/tutorial/UnitAgent.java
@@ -92,25 +92,31 @@ public class UnitAgent extends AbstractAgent {
 	
 	// tutorial outline
 	
-//  // TODO: complete the stats Value Lane
-//  // @SwimLane("stats")
-//	
-//  // HINT: Use the valueLane() method to instantiate the lane
-//  // HINT: Use the .didSet() lifecycle callback to log a message showing updates to stats
-//	
-//   @SwimLane("histogram")
-//   private final MapLane<Long, Value> histogram = this.<Long, Value>mapLane()
-//       .didUpdate((k, n, o) -> {
-//         logMessage("histogram: replaced " + k + "'s value to " + Recon.toString(n) + " from " + Recon.toString(o));
-//         // TODO: update stats with update logic
-//         
-//		 dropOldData();
-//
-//       })
-//       .didRemove((k,o) -> {
-//        // TODO: update stats with remove logic
-//
-//       });
+  // TODO: complete the stats Value Lane
+  // @SwimLane("stats")
+	
+  // HINT: Use the valueLane() method to instantiate the lane
+  // HINT: Use the .didSet() lifecycle callback to log a message showing updates to stats
+	
+   @SwimLane("histogram")
+   private final MapLane<Long, Value> histogram = this.<Long, Value>mapLane()
+       .didUpdate((k, n, o) -> {
+         logMessage("histogram: replaced " + k + "'s value to " + Recon.toString(n) + " from " + Recon.toString(o));
+         // TODO: update stats with update logic
+         
+         // HINT: access new data sent to histogram with 
+         		// n.getItem(0).longValue()
+         // HINT: use this data to calculate stats such as mean, variance, std dev, etc
+         // HINT: send new data to stats lane by calling 
+         		// stats.set($TRANSFORMED_DATA)
+         
+		 dropOldData();
+
+       })
+       .didRemove((k,o) -> {
+        // TODO: update stats with remove logic
+
+       });
 		  
   @SwimLane("history")
   private final ListLane<Value> history = this.<Value>listLane()

--- a/server/src/main/java/swim/tutorial/UnitAgent.java
+++ b/server/src/main/java/swim/tutorial/UnitAgent.java
@@ -81,7 +81,7 @@ public class UnitAgent extends AbstractAgent {
 	        final long LOCAL_AVG = localSum / (long) recentData.length;
 	        localAvg.set(LOCAL_AVG);
 	        
-	        // calculating local variance to send to stats3
+	        // calculating local variance to send to local var lane
 	        long squaredDifSum = 0; // (sum of local mean - each value)^2
 	        for (long d : recentData) squaredDifSum += (d - LOCAL_AVG)*(d - LOCAL_AVG);
 	        final long LOCAL_VAR = squaredDifSum/recentData.length;
@@ -98,13 +98,41 @@ public class UnitAgent extends AbstractAgent {
 	        dropOldData();
 	      })
 	      .didRemove((k,o) -> {
-	    	  // TODO: Finish here by adding remove logic
 	    	  // stats.put(stats.get()-o)
 	    	  
 	    	  logMessage("histogram: removed <" + k + "," + Recon.toString(o) + ">");
-	    	  countSum = 0;
-	    	  countTotal = 0;
-	    	  index = 0;
+	    	  
+	    	  // remove logic for avg lane
+	    	  countSum -= o.getItem(0).longValue();
+	    	  countTotal --;
+	    	  avg.put(countSum / countTotal)
+	    	  
+	    	  // remove logic for local avg lane
+	    	  localSum -= o.getItem(0).longValue()
+	    	  newLocAvg = localSum/(long) (recentData.length-1);
+	    	  localAvg.put(newLocAvg)
+	    	  
+	    	  // remove logic for local var lane
+	    	  
+	    	  long squaredDifSum = 0; // (sum of local mean - each value)^2
+		        for (long d : recentData) squaredDifSum += (d - LOCAL_AVG)*(d - LOCAL_AVG);
+		        final long LOCAL_VAR = squaredDifSum/recentData.length;
+		        localVar.set(LOCAL_VAR);
+
+		      for (long d : recentData) {
+		    	  if (d.equals())
+		      }
+	    	  
+		      final long LOCAL_AVG = localSum / (long) recentData.length;
+		      localAvg.set(LOCAL_AVG);
+	    	  
+	    	  squaredDifSum-()*()/
+	    	  recentData.length-1
+	    	  
+	    	  // remove logic for avg lane
+	    	  	  
+	    	  // remove logic for stats
+	    	  
 	      });
 	  
 	  	// ****************************************************************************

--- a/server/src/main/java/swim/tutorial/UnitAgent.java
+++ b/server/src/main/java/swim/tutorial/UnitAgent.java
@@ -101,7 +101,9 @@ public class UnitAgent extends AbstractAgent {
 	        dropOldData();
 	      })
 	      .didRemove((k,o) -> {
-	    	  // TODO: stats.put(stats.get()-o)
+	    	  // TODO: Finish here by adding remove logic
+	    	  // stats.put(stats.get()-o)
+	    	  
 	    	  logMessage("histogram: removed <" + k + "," + Recon.toString(o) + ">");
 	    	  count_sum = 0;
 	    	  count_total = 0;

--- a/server/src/main/java/swim/tutorial/UnitAgent.java
+++ b/server/src/main/java/swim/tutorial/UnitAgent.java
@@ -12,6 +12,8 @@ import swim.structure.Value;
 import java.util.Iterator;
 
 public class UnitAgent extends AbstractAgent {
+	
+	// ***** EXAMPLE SOLUTION ******
 	  // instance variables to track metrics going into stats
 	  private long count_sum = 0;
 	  private int count_total = 0;
@@ -90,33 +92,33 @@ public class UnitAgent extends AbstractAgent {
 	  
 	
 	
-	// tutorial outline
+  // ***** TUTORIAL TEMPLATE ******
 	
-  // TODO: complete the stats Value Lane
-  // @SwimLane("stats")
-	
-  // HINT: Use the valueLane() method to instantiate the lane
-  // HINT: Use the .didSet() lifecycle callback to log a message showing updates to stats
-	
-   @SwimLane("histogram")
-   private final MapLane<Long, Value> histogram = this.<Long, Value>mapLane()
-       .didUpdate((k, n, o) -> {
-         logMessage("histogram: replaced " + k + "'s value to " + Recon.toString(n) + " from " + Recon.toString(o));
-         // TODO: update stats with update logic
-         
-         // HINT: access new data sent to histogram with 
-         		// n.getItem(0).longValue()
-         // HINT: use this data to calculate stats such as mean, variance, std dev, etc
-         // HINT: send new data to stats lane by calling 
-         		// stats.set($TRANSFORMED_DATA)
-         
-		 dropOldData();
-
-       })
-       .didRemove((k,o) -> {
-        // TODO: update stats with remove logic
-
-       });
+//  // TODO: complete the stats Value Lane
+//  // @SwimLane("stats")
+//	
+//  // HINT: Use the valueLane() method to instantiate the lane
+//  // HINT: Use the .didSet() lifecycle callback to log a message showing updates to stats
+//	
+//   @SwimLane("histogram")
+//   private final MapLane<Long, Value> histogram = this.<Long, Value>mapLane()
+//       .didUpdate((k, n, o) -> {
+//         logMessage("histogram: replaced " + k + "'s value to " + Recon.toString(n) + " from " + Recon.toString(o));
+//         // TODO: update stats with update logic
+//         
+//         // HINT: access new data sent to histogram with 
+//         		// n.getItem(0).longValue()
+//         // HINT: use this data to calculate stats such as mean, variance, std dev, etc
+//         // HINT: send new data to stats lane by calling 
+//         		// stats.set($TRANSFORMED_DATA)
+//         
+//		 dropOldData();
+//
+//       })
+//       .didRemove((k,o) -> {
+//        // TODO: update stats with remove logic
+//
+//       });
 		  
   @SwimLane("history")
   private final ListLane<Value> history = this.<Value>listLane()

--- a/server/src/main/java/swim/tutorial/UnitAgent.java
+++ b/server/src/main/java/swim/tutorial/UnitAgent.java
@@ -13,7 +13,8 @@ import java.util.Iterator;
 
 public class UnitAgent extends AbstractAgent {
 	
-	// ***** EXAMPLE SOLUTION ******
+	  // *********************** EXAMPLE SOLUTIONS FOR STATS LANE ***********************
+	  
 	  // instance variables to track metrics going into stats
 	  private long count_sum = 0;
 	  private int count_total = 0;
@@ -45,7 +46,7 @@ public class UnitAgent extends AbstractAgent {
 	    logMessage("stats_4: local std deviation (last 5 entries) updated to " + n + " from " + o);
 	  });
 	
-	
+	  // *********************** EXAMPLE SOLUTION FOR HISTOGRAM ***********************
 	  @SwimLane("histogram")
 	  private final MapLane<Long, Value> histogram = this.<Long, Value>mapLane()
 	      .didUpdate((k, n, o) -> {
@@ -83,42 +84,13 @@ public class UnitAgent extends AbstractAgent {
 	        dropOldData();
 	      })
 	      .didRemove((k,o) -> {
-	        // update stats with remove logic
 	    	  logMessage("histogram: removed <" + k + "," + Recon.toString(o) + ">");
 	    	  count_sum = 0;
 	    	  count_total = 0;
 	    	  index = 0;
 	      });
 	  
-	
-	
-  // ***** TUTORIAL TEMPLATE ******
-	
-//  // TODO: complete the stats Value Lane
-//  // @SwimLane("stats")
-//	
-//  // HINT: Use the valueLane() method to instantiate the lane
-//  // HINT: Use the .didSet() lifecycle callback to log a message showing updates to stats
-//	
-//   @SwimLane("histogram")
-//   private final MapLane<Long, Value> histogram = this.<Long, Value>mapLane()
-//       .didUpdate((k, n, o) -> {
-//         logMessage("histogram: replaced " + k + "'s value to " + Recon.toString(n) + " from " + Recon.toString(o));
-//         // TODO: update stats with update logic
-//         
-//         // HINT: access new data sent to histogram with 
-//         		// n.getItem(0).longValue()
-//         // HINT: use this data to calculate stats such as mean, variance, std dev, etc
-//         // HINT: send new data to stats lane by calling 
-//         		// stats.set($TRANSFORMED_DATA)
-//         
-//		 dropOldData();
-//
-//       })
-//       .didRemove((k,o) -> {
-//        // TODO: update stats with remove logic
-//
-//       });
+	  	// ****************************************************************************
 		  
   @SwimLane("history")
   private final ListLane<Value> history = this.<Value>listLane()

--- a/ui/README.md
+++ b/ui/README.md
@@ -4,6 +4,11 @@
 
 The minimum you need to visualize Swim data is a Swim client. That said, Swim comes with additional tools that let you see your data right away with no extra work.
 
+#### *Try it yourself:*
+
+- [ ] *Based on changes suggested in* [*the server README*](https://github.com/swimos/tutorial/blob/tutorial_solutions/server/README.md) *, update the UI code to accommodate your new server-side*
+- [ ] *See the [**tutorial_solutions**](https://github.com/swimos/tutorial/tree/tutorial_solutions) branch for an example of this*
+
 Read [chart.html](http://github.com/swimos/tutorial/tree/master/ui/chart.html) to build your own line chart.
 
 Read [gauge.html](http://github.com/swimos/tutorial/tree/master/ui/gauge.html) to build your own gauge.

--- a/ui/README.md
+++ b/ui/README.md
@@ -4,10 +4,11 @@
 
 The minimum you need to visualize Swim data is a Swim client. That said, Swim comes with additional tools that let you see your data right away with no extra work.
 
-#### *Try it yourself:*
+#### *Example Solutions*
 
-- [ ] *Based on changes suggested in* [*the server README*](https://github.com/swimos/tutorial/blob/tutorial_solutions/server/README.md) *, update the UI code to accommodate your new server-side*
-- [ ] *See the [**tutorial_solutions**](https://github.com/swimos/tutorial/tree/tutorial_solutions) branch for an example of this*
+- [ ] *Use the dropdown menu to toggle between three different web agents for each UI demo*
+- [ ] *See how each UI demo updates its downlinks when new web agents are selected*
+- [ ] *Explore how to include simple visual changes (e.g. color changes for different agents) using the* [*swim UI framework*](https://docs.swimos.org/js/latest/index.html)
 
 Read [chart.html](http://github.com/swimos/tutorial/tree/master/ui/chart.html) to build your own line chart.
 

--- a/ui/chart.html
+++ b/ui/chart.html
@@ -5,54 +5,114 @@
     <meta name="viewport" content="width=device-width, height=device-height, initial-scale=1, shrink-to-fit=no, viewport-fit=cover" />
   </head>
   <body style="display: flex; justify-content: center; align-items: center; width: 100vw; height: 100vh; margin: 0;">
+
     <div id="app" style="display: flex; width: 67%; height: 67%; flex-direction: column;">
     </div>
+
+    <div>
+      <label for="agents">Choose a web agent:</label>
+
+      <select name="agents" id="web_agent_select" onchange="update(this.value)">
+        <option value="/unit/master" style = "color:#50e3c2">/unit/master</option>
+        <option value="/unit/secondAgent" style = "color:#3c52f0">/unit/secondAgent</option>
+        <option value="/unit/thirdAgent" style = "color:#212326">/unit/thirdAgent</option>
+      </select>
+    </div>
+
     <script src="https://cdn.swimos.org/js/3.10.2/swim-system.js"></script>
     <script>
 
-const app = new swim.HtmlAppView(document.getElementById("app"));
+    const app = new swim.HtmlAppView(document.getElementById("app"));
 
-const chartCanvas = app.append('div').position('relative').append("canvas");
+    const chartCanvas = app.append('div').position('relative').append("canvas");
 
-const tween = swim.Transition.duration(1000);
+    const tween = swim.Transition.duration(1000);
 
-/* Chart View */
-const chart = new swim.ChartView()
-    .bottomAxis(swim.AxisView.bottom("time"))
-    .leftAxis(swim.AxisView.left("0...120"))
-    .domainColor("#4a4a4a")
-    .tickMarkColor("#4a4a4a")
-    .font("12px sans-serif")
-    .textColor("#4a4a4a");
-chartCanvas.append(chart);
+    /* Chart View */
+    const chart = new swim.ChartView()
+        .bottomAxis(swim.AxisView.bottom("time"))
+        .leftAxis(swim.AxisView.left("0...120"))
+        .domainColor("#4a4a4a")
+        .tickMarkColor("#4a4a4a")
+        .font("12px sans-serif")
+        .textColor("#4a4a4a");
+    chartCanvas.append(chart);
 
-const plot = new swim.LineGraphView()
-    .stroke("#50e3c2")
-    .strokeWidth(2);
-chart.addPlot(plot);
+    const plot = new swim.LineGraphView()
+        .stroke("#50e3c2")
+        .strokeWidth(2);
+    chart.addPlot(plot);
 
-function addToPlot(key, value) {
-  const time = key.numberValue();
-  const v = value.get("count").numberValue(0);
-  plot.insertDatum({x: time, y: v, opacity: void 0});
-}
+    function addToPlot(key, value) {
+      const time = key.numberValue();
+      const v = value.get("count").numberValue(0);
+      plot.insertDatum({x: time, y: v, opacity: void 0});
+    }
 
-function removeFromPlot(key) {
-  const time = key.numberValue();
-  plot.removeDatum(time);
-}
+    function removeFromPlot(key) {
+      const time = key.numberValue();
+      plot.removeDatum(time);
+    }
 
-const histogramLink = swim.downlinkMap()
-    .hostUri("warp://localhost:9001")
-    .nodeUri("/unit/master")
-    .laneUri("histogram")
-    .didUpdate(function(key, value) {
-      addToPlot(key, value);
-    })
-    .didRemove(function(key) {
-      removeFromPlot(key);
-    })
-    .open();
+    // Allowing for Web Agent selection by html dropdown menu
+
+    var agent_URI = "/unit/master";
+
+    // runs once
+    var histogramLink = swim.downlinkMap()
+        .hostUri("warp://localhost:9001")
+        .nodeUri(agent_URI)
+        .laneUri("histogram")
+        .didUpdate(function(key, value) {
+          addToPlot(key, value);
+        })
+        .didRemove(function(key) {
+          removeFromPlot(key);
+        })
+        .open();
+
+
+    // update logic runs whenever a new dropdown option is selected
+    function update(val) {
+      if (histogramLink) {
+        // close downlink on update
+        histogramLink.close();
+
+        // update the node URI used in histogramLink to match the selected agent
+        agent_URI = document.getElementById('web_agent_select').value;
+        console.log(agent_URI);
+
+        histogramLink = swim.downlinkMap()
+            .hostUri("warp://localhost:9001")
+            .nodeUri(agent_URI)
+            .laneUri("histogram")
+            .didUpdate(function(key, value) {
+              addToPlot(key, value);
+            })
+            .didRemove(function(key) {
+              removeFromPlot(key);
+            })
+            .open();
+
+        // switch statement that changes the plot color according to web agent
+        var color = "#50e3c2";
+        switch(agent_URI) {
+          case "/unit/secondAgent":
+            color = "#3c52f0";
+            break;
+          case "/unit/thirdAgent":
+              color = "#212326";
+              break;
+          default:
+            // for master web agent
+            color = "#50e3c2";
+        }
+        plot
+        .stroke(color);
+        chart.addPlot(plot);
+      }
+    }
+
     </script>
   </body>
 </html>

--- a/ui/gauge.html
+++ b/ui/gauge.html
@@ -39,20 +39,20 @@ const gauge = new swim.GaugeView()
 gaugeCanvas.append(gauge);
 
 const avgDial = new swim.DialView()
-    .label("AVG");
-gauge.setChildView("AVG", avgDial);
+    .label("avg");
+gauge.setChildView("avg", avgDial);
 
 const locAvgDial = new swim.DialView()
-    .label("LOC_AVG");
-gauge.setChildView("LOC_AVG", locAvgDial);
+    .label("localAvg");
+gauge.setChildView("localAvg", locAvgDial);
 
 const locVarDial = new swim.DialView()
-    .label("LOC_VAR");
-gauge.setChildView("LOC_VAR", locVarDial);
+    .label("localVar");
+gauge.setChildView("localVar", locVarDial);
 
 const locStdDevDial = new swim.DialView()
-    .label("LOC_STD_DEV");
-gauge.setChildView("LOC_STD_DEV", locStdDevDial);
+    .label("localStdDev");
+gauge.setChildView("localStdDev", locStdDevDial);
 
 var colorLow = "#50e3c2";
 var colorMed = "#359680";
@@ -80,10 +80,10 @@ var valueLink = swim.downlinkValue()
     .nodeUri(agent_URI)
     .laneUri("stats")
     .didSet(function (value) {
-      updateDial(avgDial, 60, "AVG", value);
-      updateDial(locAvgDial, 60, "LOCAL_AVG", value);
-      updateDial(locVarDial, 1000, "LOCAL_VAR", value);
-      updateDial(locStdDevDial, 40, "LOCAL_STD_DEV", value)
+      updateDial(avgDial, 60, "avg", value);
+      updateDial(locAvgDial, 60, "localAvg", value);
+      updateDial(locVarDial, 1000, "localVar", value);
+      updateDial(locStdDevDial, 40, "localStdDev", value)
     })
     .open();
 
@@ -103,10 +103,10 @@ function update(val) {
         .nodeUri(agent_URI)
         .laneUri("stats")
         .didSet(function (value) {
-          updateDial(avgDial, 60, "AVG", value);
-          updateDial(locAvgDial, 60, "LOCAL_AVG", value);
-          updateDial(locVarDial, 1000, "LOCAL_VAR", value);
-          updateDial(locStdDevDial, 40, "LOCAL_STD_DEV", value)
+          updateDial(avgDial, 60, "avg", value);
+          updateDial(locAvgDial, 60, "localAvg", value);
+          updateDial(locVarDial, 1000, "localVar", value);
+          updateDial(locStdDevDial, 40, "localStdDev", value)
         })
         .open();
 

--- a/ui/gauge.html
+++ b/ui/gauge.html
@@ -33,26 +33,26 @@ const gauge = new swim.GaugeView()
     .sweepAngle(swim.Angle.rad(3 * Math.PI / 2))
     .dialColor("#cccccc")
     .meterColor("#989898")
-    .title(new swim.TextRunView("Mean, Local Mean, Local Variance, Local Standard Deviation").font("10px sans-serif"))
+    .title(new swim.TextRunView("Mean, Local Mean, Local Variance, Local Standard Deviation").font("10px sans-serif")) // TextView Docs to find newline
     .font("10px sans-serif")
     .textColor("#4a4a4a");
 gaugeCanvas.append(gauge);
 
 const avgDial = new swim.DialView()
     .label("AVG");
-gauge.setChildView("avg", avgDial);
+gauge.setChildView("AVG", avgDial);
 
 const locAvgDial = new swim.DialView()
     .label("LOC_AVG");
-gauge.setChildView("loc_avg", locAvgDial);
+gauge.setChildView("LOC_AVG", locAvgDial);
 
 const locVarDial = new swim.DialView()
     .label("LOC_VAR");
-gauge.setChildView("loc_var", locVarDial);
+gauge.setChildView("LOC_VAR", locVarDial);
 
 const locStdDevDial = new swim.DialView()
     .label("LOC_STD_DEV");
-gauge.setChildView("loc_std_dev", locStdDevDial);
+gauge.setChildView("LOC_STD_DEV", locStdDevDial);
 
 var colorLow = "#50e3c2";
 var colorMed = "#359680";
@@ -80,10 +80,10 @@ var valueLink = swim.downlinkValue()
     .nodeUri(agent_URI)
     .laneUri("stats")
     .didSet(function (value) {
-      updateDial(avgDial, 60, "avg", value);
-      updateDial(locAvgDial, 60, "local_avg", value);
-      updateDial(locVarDial, 1000, "local_variance", value);
-      updateDial(locStdDevDial, 40, "local_std_dev", value)
+      updateDial(avgDial, 60, "AVG", value);
+      updateDial(locAvgDial, 60, "LOCAL_AVG", value);
+      updateDial(locVarDial, 1000, "LOCAL_VAR", value);
+      updateDial(locStdDevDial, 40, "LOCAL_STD_DEV", value)
     })
     .open();
 
@@ -103,10 +103,10 @@ function update(val) {
         .nodeUri(agent_URI)
         .laneUri("stats")
         .didSet(function (value) {
-          updateDial(avgDial, 60, "avg", value);
-          updateDial(locAvgDial, 60, "local_avg", value);
-          updateDial(locVarDial, 1000, "local_variance", value);
-          updateDial(locStdDevDial, 40, "local_std_dev", value)
+          updateDial(avgDial, 60, "AVG", value);
+          updateDial(locAvgDial, 60, "LOCAL_AVG", value);
+          updateDial(locVarDial, 1000, "LOCAL_VAR", value);
+          updateDial(locStdDevDial, 40, "LOCAL_STD_DEV", value)
         })
         .open();
 

--- a/ui/gauge.html
+++ b/ui/gauge.html
@@ -7,6 +7,17 @@
   <body style="display: flex; justify-content: center; align-items: center; width: 100vw; height: 100vh; margin: 0;">
     <div id="app" style="display: flex; width: 67%; height: 67%; flex-direction: column;">
     </div>
+
+    <div>
+      <label for="agents">Choose a web agent:</label>
+
+      <select name="agents" id="web_agent_select" onchange="update(this.value)">
+        <option value="/unit/master" style = "color:#50e3c2">/unit/master</option>
+        <option value="/unit/secondAgent" style = "color:#3c52f0">/unit/secondAgent</option>
+        <option value="/unit/thirdAgent" style = "color:#212326">/unit/thirdAgent</option>
+      </select>
+    </div>
+
     <script src="https://cdn.swimos.org/js/3.10.2/swim-system.js"></script>
     <script>
 
@@ -39,20 +50,30 @@ const bazDial = new swim.DialView()
     .label("BAZ");
 gauge.setChildView("baz", bazDial);
 
+var colorLow = "#50e3c2";
+var colorMed = "#359680";
+var colorHigh = "#1f5c4e"
+
 function updateDial(dial, max, key, value) {
   const v = value.get(key).numberValue();
   const percent = v / max;
   const legend = key + ": " + (v) + " out of " + max;
   dial.value(v, tween)
       .total(max)
-      .meterColor(percent < 0.5 ? "#989898" : percent < 0.9 ? "#4a4a4a" : "#000000", tween);
+      .meterColor(percent < 0.5 ? colorLow : percent < 0.9 ? colorMed : colorHigh, tween);
   dial.label().text(legend);
 }
 
+
+// switching between web agents
+var agent_URI = "/unit/master";
+
 /* Data Subscriptions */
-const valueLink = swim.downlinkValue()
+
+// runs once
+var valueLink = swim.downlinkValue()
     .hostUri("warp://localhost:9001")
-    .nodeUri("/unit/master")
+    .nodeUri(agent_URI)
     .laneUri("latest")
     .didSet(function (value) {
       updateDial(fooDial, 70, "foo", value);
@@ -60,6 +81,49 @@ const valueLink = swim.downlinkValue()
       updateDial(bazDial, 210, "baz", value);
     })
     .open();
+
+
+// update logic runs whenever a new dropdown option is selected
+function update(val) {
+  if (valueLink) {
+    // close downlink on update
+    valueLink.close();
+
+    // update the node URI used in histogramLink to match the selected agent
+    agent_URI = document.getElementById('web_agent_select').value;
+    console.log(agent_URI);
+
+    valueLink = swim.downlinkValue()
+        .hostUri("warp://localhost:9001")
+        .nodeUri(agent_URI)
+        .laneUri("latest")
+        .didSet(function (value) {
+          updateDial(fooDial, 70, "foo", value);
+          updateDial(barDial, 140, "bar", value);
+          updateDial(bazDial, 210, "baz", value);
+        })
+        .open();
+
+    // switch statement that changes the plot color according to web agent
+    switch(agent_URI) {
+      case "/unit/secondAgent":
+        colorLow = "#3c52f0";
+        colorMed = "#182373";
+        colorHigh = "#0b1347"
+        break;
+      case "/unit/thirdAgent":
+          colorLow = "#d5d9e0";
+          colorMed = "#6d7178";
+          colorHigh = "#000000"
+          break;
+      default:
+        // for master web agent
+        colorLow = "#50e3c2";
+        colorMed = "#359680";
+        colorHigh = "#1f5c4e"
+    }
+  }
+}
 
     </script>
   </body>

--- a/ui/gauge.html
+++ b/ui/gauge.html
@@ -33,22 +33,26 @@ const gauge = new swim.GaugeView()
     .sweepAngle(swim.Angle.rad(3 * Math.PI / 2))
     .dialColor("#cccccc")
     .meterColor("#989898")
-    .title(new swim.TextRunView("Foo, Bar, Baz").font("20px sans-serif"))
-    .font("14px sans-serif")
+    .title(new swim.TextRunView("Mean, Local Mean, Local Variance, Local Standard Deviation").font("10px sans-serif"))
+    .font("10px sans-serif")
     .textColor("#4a4a4a");
 gaugeCanvas.append(gauge);
 
-const fooDial = new swim.DialView()
-    .label("FOO");
-gauge.setChildView("foo", fooDial);
+const avgDial = new swim.DialView()
+    .label("AVG");
+gauge.setChildView("avg", avgDial);
 
-const barDial = new swim.DialView()
-    .label("BAR");
-gauge.setChildView("bar", barDial);
+const locAvgDial = new swim.DialView()
+    .label("LOC_AVG");
+gauge.setChildView("loc_avg", locAvgDial);
 
-const bazDial = new swim.DialView()
-    .label("BAZ");
-gauge.setChildView("baz", bazDial);
+const locVarDial = new swim.DialView()
+    .label("LOC_VAR");
+gauge.setChildView("loc_var", locVarDial);
+
+const locStdDevDial = new swim.DialView()
+    .label("LOC_STD_DEV");
+gauge.setChildView("loc_std_dev", locStdDevDial);
 
 var colorLow = "#50e3c2";
 var colorMed = "#359680";
@@ -74,11 +78,12 @@ var agent_URI = "/unit/master";
 var valueLink = swim.downlinkValue()
     .hostUri("warp://localhost:9001")
     .nodeUri(agent_URI)
-    .laneUri("latest")
+    .laneUri("stats")
     .didSet(function (value) {
-      updateDial(fooDial, 70, "foo", value);
-      updateDial(barDial, 140, "bar", value);
-      updateDial(bazDial, 210, "baz", value);
+      updateDial(avgDial, 60, "avg", value);
+      updateDial(locAvgDial, 60, "local_avg", value);
+      updateDial(locVarDial, 1000, "local_variance", value);
+      updateDial(locStdDevDial, 40, "local_std_dev", value)
     })
     .open();
 
@@ -96,11 +101,12 @@ function update(val) {
     valueLink = swim.downlinkValue()
         .hostUri("warp://localhost:9001")
         .nodeUri(agent_URI)
-        .laneUri("latest")
+        .laneUri("stats")
         .didSet(function (value) {
-          updateDial(fooDial, 70, "foo", value);
-          updateDial(barDial, 140, "bar", value);
-          updateDial(bazDial, 210, "baz", value);
+          updateDial(avgDial, 60, "avg", value);
+          updateDial(locAvgDial, 60, "local_avg", value);
+          updateDial(locVarDial, 1000, "local_variance", value);
+          updateDial(locStdDevDial, 40, "local_std_dev", value)
         })
         .open();
 

--- a/ui/pie.html
+++ b/ui/pie.html
@@ -114,6 +114,7 @@ function update(val) {
               .nodeUri(agent_URI)
               .laneUri("latest")
               .didSet(function (value) {
+                // TODO: change to stats
                 updateSlice("foo", value);
                 updateSlice("bar", value);
                 updateSlice("baz", value);

--- a/ui/pie.html
+++ b/ui/pie.html
@@ -114,7 +114,6 @@ function update(val) {
               .nodeUri(agent_URI)
               .laneUri("latest")
               .didSet(function (value) {
-                // TODO: change to stats
                 updateSlice("foo", value);
                 updateSlice("bar", value);
                 updateSlice("baz", value);

--- a/ui/pie.html
+++ b/ui/pie.html
@@ -7,6 +7,17 @@
   <body style="display: flex; justify-content: center; align-items: center; width: 100vw; height: 100vh; margin: 0;">
     <div id="app" style="display: flex; width: 67%; height: 67%; flex-direction: column;">
     </div>
+
+    <div>
+      <label for="agents">Choose a web agent:</label>
+
+      <select name="agents" id="web_agent_select" onchange="update(this.value)">
+        <option value="/unit/master" style = "color:#50e3c2">/unit/master</option>
+        <option value="/unit/secondAgent" style = "color:#3c52f0">/unit/secondAgent</option>
+        <option value="/unit/thirdAgent" style = "color:#212326">/unit/thirdAgent</option>
+      </select>
+    </div>
+
     <script src="https://cdn.swimos.org/js/3.10.2/swim-system.js"></script>
     <script>
 
@@ -17,15 +28,18 @@ const pieCanvas = app.append('div').position('relative').append("canvas");
 const tween = swim.Transition.duration(1000);
 
 /* Pie View */
-const sliceColors = [swim.Color.parse("#00a6ed"),
-    swim.Color.parse("#6acd00"),
-    swim.Color.parse("#c200fa")];
+var color1 = "#50e3c2";
+var color2 = "#359680";
+var color3 = "#1f5c4e"
+var sliceColors = [swim.Color.parse(color3),
+    swim.Color.parse(color2),
+    swim.Color.parse(color1)];
 const pie = new swim.PieView()
     // .innerRadius("15%")
     .outerRadius("25%")
     .tickColor("#b7b7b7")
     .font("14px sans-serif")
-    .textColor("#4a4a4a");
+    .textColor("#000000");
 pieCanvas.append(pie);
 const pieIndices = {"foo": 0, "bar": 1, "baz": 2};
 
@@ -33,23 +47,28 @@ function updateSlice(key, value) {
   const v = value.get(key).numberValue();
   let slice = pie.getChildView(key);
   if (slice) {
+    sliceColor = sliceColors[pieIndices[key]];
+    slice.sliceColor(sliceColor)
     slice.value(v, tween);
     slice.label().text(v);
   } else {
-    const sliceColor = sliceColors[pieIndices[key]];
+    var sliceColor = sliceColors[pieIndices[key]];
     slice = new swim.SliceView()
         .value(v)
         .sliceColor(sliceColor)
         .label(v.toFixed())
         .legend(key);
-    pie.setChildView(key, slice);    
+    pie.setChildView(key, slice);
   }
 }
 
+// switching between web agents
+var agent_URI = "/unit/master";
+
 /* Data Subscriptions */
-const valueLink = swim.downlinkValue()
+var valueLink = swim.downlinkValue()
     .hostUri("warp://localhost:9001")
-    .nodeUri("/unit/master")
+    .nodeUri(agent_URI)
     .laneUri("latest")
     .didSet(function (value) {
       updateSlice("foo", value);
@@ -57,6 +76,51 @@ const valueLink = swim.downlinkValue()
       updateSlice("baz", value);
     })
     .open();
+
+// update logic runs whenever a new dropdown option is selected
+function update(val) {
+  if (valueLink) {
+    // close downlink on update
+    valueLink.close();
+
+    // update the node URI used in histogramLink to match the selected agent
+    agent_URI = document.getElementById('web_agent_select').value;
+    console.log(agent_URI);
+
+      // switch statement that changes the plot color according to web agent
+      switch(agent_URI) {
+        case "/unit/secondAgent":
+          color1 = "#7a85d6"
+          color2 = "#3c52f0";
+          color3 = "#182373";
+          break;
+        case "/unit/thirdAgent":
+          color1 = "#d5d9e0";
+          color2 = "#9da4b0"
+          color3 = "#6d7178";
+          break;
+        default:
+          // for master web agent
+          color1 = "#50e3c2";
+          color2 = "#359680";
+          color3 = "#1f5c4e"
+      }
+      sliceColors = [swim.Color.parse(color3),
+          swim.Color.parse(color2),
+          swim.Color.parse(color1)];
+
+          valueLink = swim.downlinkValue()
+              .hostUri("warp://localhost:9001")
+              .nodeUri(agent_URI)
+              .laneUri("latest")
+              .didSet(function (value) {
+                updateSlice("foo", value);
+                updateSlice("bar", value);
+                updateSlice("baz", value);
+              })
+              .open();
+    }
+  }
 
     </script>
   </body>


### PR DESCRIPTION
# Description

Offers a potential implementation for the instructions set out in the `exercises` branch (#6) and addresses #5 

_in server/DataSource.java_
- adds two new web agents `/unit/secondAgent` and `/unit/thirdAgent`
- manipulates the data sent to each distinct web agent to make their differences clearer

_in server/UnitAgents.java_
- creates simple value lanes of type Long to show single statistics
- offers an alternative design choice to send multiple stats to one value lane of type Value

_in ui/chart.html, ui/gauge.html, ui/pie.html_
- adds a dropdown menu to select the current web agent shown and toggle between all three
- updates the lane downlink and nodeURI whenever the current agent changes
- visually emphasize the differences between agents with a color palette change
- change gauge to draw info from the new stats lane (instead of latest)

## Points to be addressed before merge

- [ ] Any style conventions
- [ ] Suggested refactoring/code clarification
- [ ] Places where in-depth comments could be added to explain what is happening on a particular line
- [ ] Missing aspects of swim functionality that would be useful for a user to learn
